### PR TITLE
Use new environment variable for better temp dir location customisation

### DIFF
--- a/post-processor/vagrant/post-processor.go
+++ b/post-processor/vagrant/post-processor.go
@@ -141,7 +141,12 @@ func (p *PostProcessor) PostProcessProvider(name string, provider Provider, ui p
 	}
 
 	// Create a temporary directory for us to build the contents of the box in
-	dir, err := tmp.Dir("packer")
+	var dir = ""
+	if envDir := os.Getenv("PACKER_TEMP_DIR"); envDir != "" {
+		dir, err = os.MkdirTemp(envDir, "packer")
+	} else {
+		dir, err = tmp.Dir("packer")
+	}
 	if err != nil {
 		return nil, false, err
 	}


### PR DESCRIPTION
If the environment varible PACKER_TEMP_DIR is set, then the vagrant post-processor will use this instead of the system defaults for the temp directory location.